### PR TITLE
[Feature] #64 - Add ability to specify map in Dataset-Generator

### DIFF
--- a/code/perception/src/dataset_generator.py
+++ b/code/perception/src/dataset_generator.py
@@ -246,15 +246,21 @@ def create_argparse():
         help='set up an empty world and spawn ego vehicle',
         default=False
     )
+    argparser.add_argument(
+        '--town',
+        metavar='T',
+        default='Town12',
+        help='town to load'
+    )
     return argparser
 
 
 if __name__ == '__main__':
-    towns = ["Town01", "Town02", "Town03", "Town04", "Town05", "Town06",
-             "Town07", "Town10", "Town11", "Town12"]
-    town = towns[2]
+    towns = {"Town01", "Town02", "Town03", "Town04", "Town05", "Town06",
+             "Town07", "Town10", "Town11", "Town12"}
     argparser = create_argparse()
     args = argparser.parse_args()
+    town = args.town
     output_dir = args.output_dir
     host = args.host
     port = args.port
@@ -262,10 +268,11 @@ if __name__ == '__main__':
 
     client = carla.Client(host, port)
     client.set_timeout(30)
-    world = client.load_world(town)
+    world = client.load_world(town) if use_empty_world else client.get_world()
     world.wait_for_tick()
 
-    output_dir = os.path.join(output_dir, town[-2:])
+    output_dir = os.path.join(output_dir, world.get_map().name[-2:])
+    print("Saving images to {}".format(output_dir))
 
     if use_empty_world:
         ego_vehicle = setup_empty_world(client)

--- a/doc/06_perception/01_dataset_generator.md
+++ b/doc/06_perception/01_dataset_generator.md
@@ -15,14 +15,14 @@ Korbinian Stein
 
 <!-- TOC -->
 
-* [Dataset generator](#dataset-generator)
-  * [Author](#author)
-  * [Date](#date)
-  * [Necessary adjustments](#necessary-adjustments)
-    * [Dockerfile](#dockerfile)
-    * [docker-compose.yml](#docker-composeyml)
-  * [Usage](#usage)
-    * [Using with leaderboard](#using-with-leaderboard)
+- [Dataset generator](#dataset-generator)
+  - [Author](#author)
+  - [Date](#date)
+  - [Necessary adjustments](#necessary-adjustments)
+    - [Dockerfile](#dockerfile)
+    - [docker-compose.yml](#docker-composeyml)
+  - [Usage](#usage)
+    - [Using with leaderboard](#using-with-leaderboard)
 
 <!-- TOC -->
 
@@ -102,6 +102,9 @@ camera images in four directions: `[center, left, right, back]`.
 
 We then store these images in the output directory can be specified with the `--output-dir`
 flag.
+
+Specify the desired map via `--town` and use `TownXX` with XX being 01, 02, ..., 07, 10, 11, 12.
+Default value is `Town12` like used in leaderboard 2.0.
 
 ### Using with leaderboard
 


### PR DESCRIPTION
# Description

Adds the ability to specify map in Dataset-Generator.
Also doesn't force a world-reload when using without `use_empty_world` so it can be used with a running evaluation scenario - like anticipated as stated in the [docs](https://github.com/una-auxme/paf23/blob/main/doc/06_perception/01_dataset_generator.md#using-with-leaderboard).

Fixes #64

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Does this PR introduce a breaking change?

No

## Most important changes

Specifying the desired map.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

