### PR TITLE
Revert 63 add-to-project action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,6 +16,6 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/una-auxme/projects/3
           # https://github.com/orgs/<orgName>/projects/<projectNumber>
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           # labeled: bug, needs-triage
           # label-operator: OR


### PR DESCRIPTION
Reverts una-auxme/paf23#90 as GITHUB_TOKEN doesn't have the rights to edit projects.

Solving this requires a repo admin to add `ADD_TO_PROJECT_PAT` as token in this repo's settings, like described [here](https://github.com/actions/add-to-project/tree/v0.3.0/?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository).