### PR TITLE
feat: hotfixing steering for leaderboard

### DIFF
--- a/code/acting/launch/acting.launch
+++ b/code/acting/launch/acting.launch
@@ -31,12 +31,12 @@
     </node>
     -->
 
-    <!-- ______OBSOLETES______
     <node pkg="acting" type="stanley_controller.py" name="stanley_controller" output="screen">
         <param name="control_loop_rate" value="$(arg control_loop_rate)" />
         <param name="role_name" value="$(arg role_name)" />
     </node>
 
+    <!-- ______OBSOLETES______
     <node pkg="acting" type="acting_velocity_publisher.py" name="acting_velocity_publisher" output="screen">
         <param name="role_name" value="$(arg role_name)" />
         <param name="control_loop_rate" value="0.2" />
@@ -56,6 +56,6 @@
 
     <!-- Some plot nodes for debugging speed/steering etc. -->
     <!--node pkg="rqt_plot" type="rqt_plot" output="screen" name="rqt_plot_speed" args="/carla/hero/Speed /paf/hero/target_velocity /paf/hero/throttle /paf/hero/brake"/-->
-    <node pkg="rqt_plot" type="rqt_plot" output="screen" name="rqt_plot_steering" args="/paf/hero/pure_pursuit_steer /carla/hero/vehicle_control_cmd/steer /paf/hero/pure_p_debug/l_distance"/>
+    <!--node pkg="rqt_plot" type="rqt_plot" output="screen" name="rqt_plot_steering" args="/paf/hero/pure_pursuit_steer /carla/hero/vehicle_control_cmd/steer /paf/hero/pure_p_debug/l_distance"/-->
 
 </launch>

--- a/code/acting/src/acting/pure_pursuit_controller.py
+++ b/code/acting/src/acting/pure_pursuit_controller.py
@@ -20,9 +20,10 @@ K_LAD = 0.85
 MIN_LA_DISTANCE = 2
 MAX_LA_DISTANCE = 25
 # Tuneable Factor before Publishing
-# "-" because it is inverted to the steering carla expects
-# "4.75" proved to be important for a good steering (see tuning-documentation)
-K_PUB = (-4.75)
+# "-1" because it is inverted to the steering carla expects
+# "4.75" proved to be important for a good steering
+# ONLY IN DEV.LAUNCH? (see documentation)
+K_PUB = -0.85  # (-4.75)
 # Constant: wheelbase of car
 L_VEHICLE = 2.85
 

--- a/code/acting/src/acting/stanley_controller.py
+++ b/code/acting/src/acting/stanley_controller.py
@@ -15,7 +15,7 @@ from acting.msg import StanleyDebug
 from helper_functions import vector_angle
 from trajectory_interpolation import points_to_vector
 
-K_CROSSERR = 1.24
+K_CROSSERR = 0.4  # 1.24
 
 
 class StanleyController(CompatibleNode):
@@ -250,11 +250,8 @@ class StanleyController(CompatibleNode):
         :return:
         """
         dist = self.__dist_to(pos)
-
-        # +1.4 in Headingdirection = get front axle instead of the cars middle
-        # heading_deg = self.__heading * 180 / math.pi
-        x = self.__position[0]  # + 1.4 * cos(heading_deg)
-        y = self.__position[1]  # + 1.4 * sin(heading_deg)
+        x = self.__position[0]
+        y = self.__position[1]
 
         alpha = 0
         if self.__heading is not None:


### PR DESCRIPTION
# Description
Since all Tuning, Testing etc for Acting (Steering in particular) was done in dev.launch with perfect Sensors, the very well tuned PurePursuit Controller would be expected to outperform in the leaderboard-enviroment aswell. This is NOT the case (and we do not know why exactly). 
Bringing back Stanley Controller (with a new, softer tuning to regard Sensor-Flickering) for velocities of 6+ m/s and retuning PurePursuit Controllers amplification factor (from 4.75 to under 1, again to regard Sensor-Flickering) should highly increase driving score.
Again I do not exactly know, why the well-tested and goodworking tuning from dev.launch does not work in the leaderboard. So this is a rather "dirty" hotfix (but it works).

Fixes #216  (issue)

## Type of change

* PurePursuit amplification factor retuned for leaderboard
* Stanley is back, retuned for leaderboard

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

