### PR TITLE
Update config-comlipy.yml to be only a warning

### DIFF
--- a/build/config-comlipy.yml
+++ b/build/config-comlipy.yml
@@ -6,6 +6,7 @@ rules:
   scope-min-length:
     applicable: 'always'
     value: 2
+    level: 1
   type-enum:
     applicable: 'always'
     value:
@@ -13,10 +14,10 @@ rules:
       - 'feat'
       - 'fix'
       - 'other'
-    level: 2
+    level: 1
   subject-case:
     applicable: 'never'
     value:
       - 'upper-case'
-    level: 2
+    level: 1
 


### PR DESCRIPTION
# Description

remove error messages because the commit message is not following the rules.

Fixes #273 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the enforcement levels of specific rules to indicate a lower severity for `scope-min-length`, `type-enum`, and `subject-case`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->